### PR TITLE
Add simple func to allow calculating all adjacent geohashs in a single call

### DIFF
--- a/geohash.go
+++ b/geohash.go
@@ -76,6 +76,21 @@ func CalculateAdjacent(s, dir string) string {
 	return base + string(base32[strings.Index(neighbors[dirInt][oddEven], lastChr)])
 }
 
+// Shortcut to calculate all adjacent geohashes.
+func CalculateAllAdjacent(s string) []string {
+	values := []string{}
+	directions := []string{"top", "right", "bottom", "left"}
+	for _, direction := range directions {
+		neighbour := CalculateAdjacent(s, direction)
+		values = append(values, neighbour)
+		if direction == "top" || direction == "bottom" {
+			values = append(values, CalculateAdjacent(neighbour, "right"))
+			values = append(values, CalculateAdjacent(neighbour, "left"))
+		}
+	}
+	return values
+}
+
 // Struct for passing Box.
 type BoundingBox struct {
 	sw     LatLng


### PR DESCRIPTION
Hi,

Thanks for implementing the algorithm!  This is just a quick addition to allow a single call to return all surrounding hashes.  Results in a []string with eight values representing all surrounding hashes for a particular centre hash.

Regards,

Ben Phegan
