### PR TITLE
added variable precision geohash encoding

### DIFF
--- a/geohash.go
+++ b/geohash.go
@@ -177,14 +177,19 @@ func Decode(geohash string) *BoundingBox {
 	}
 }
 
-// Create a geohash based on LatLng coordinates
+// Create a geohash with 12 positions based on LatLng coordinates
 func Encode(latitude, longitude float64) string {
+	return EncodeWithPrecision(latitude, longitude, 12)
+}
+
+// Create a geohash with given precision (number of characters of the resulting
+// hash) based on LatLng coordinates
+func EncodeWithPrecision(latitude, longitude float64, precision int) string {
 	isEven := true
 	lat := []float64{-90, 90}
 	lng := []float64{-180, 180}
 	bit := 0
 	ch := 0
-	precision := 12
 	var geohash bytes.Buffer
 	var mid float64
 	for geohash.Len() < precision {

--- a/geohash_test.go
+++ b/geohash_test.go
@@ -89,4 +89,15 @@ func TestEncode(t *testing.T) {
 		}
 	}
 
+	for prec := range []int{3, 4, 5, 6, 7, 8} {
+		for _, test := range tests {
+			geohash := EncodeWithPrecision(test.latlng.lat, test.latlng.lng, prec)
+			if len(geohash) != prec {
+				t.Errorf("expected len %d, got %d", prec, len(geohash))
+			}
+			if test.geohash[0:prec] != geohash {
+				t.Errorf("expectd %s, got %s", test.geohash, geohash)
+			}
+		}
+	}
 }


### PR DESCRIPTION
The precision of the resulting geohash was hard coded to 12. This change
adds the possibility to retrieve a geohash with a different precision.
To be compatible with the current API this functionality was added to a
new method EncodeWithPrecision. The old Encode functions calls the new
one with the value set to 12.
